### PR TITLE
Update README.md to include instructions for OSX.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # neural nets are weird
 
-Source code for the article "How to trick a neural network into thinking a panda is a vulture". Here's how to get it going! It will download about 1.5GB and take maybe half an hour to set up and compile everything, so don't expect it to be instant. Tested on Linux, untested on OS X.
+Source code for the article [How to trick a neural network into thinking a panda is a vulture](https://codewords.recurse.com/issues/five/why-do-neural-networks-think-a-panda-is-a-vulture). Here's how to get it going! It will download about 1.5GB and take maybe half an hour to set up and compile everything, so don't expect it to be instant. Tested on Linux and OS X.
 
 ```
 git clone https://github.com/jvns/neural-nets-are-weird
@@ -9,4 +9,6 @@ docker build -t neural-nets-fun:caffe .
 docker run -i -p 9990:8888 -v $PWD:/neural-nets -t neural-nets-fun:caffe /bin/bash -c 'export PYTHONPATH=/opt/caffe/python && cd /neural-nets && ipython notebook --no-browser --ip 0.0.0.0'
 ```
 
-Once you've run those commands, click on this link: [http://localhost:9990/notebooks/notebooks/neural-nets-are-weird.ipynb](http://localhost:9990/notebooks/notebooks/neural-nets-are-weird.ipynb) and you should be good to go! This starts an IPython Notebook server, which lets you run code interactively.
+**On Linux:** Once you've run those commands, click on this link: [http://localhost:9990/notebooks/notebooks/neural-nets-are-weird.ipynb](http://localhost:9990/notebooks/notebooks/neural-nets-are-weird.ipynb) and you should be good to go! This starts an IPython Notebook server, which lets you run code interactively.
+
+**On OSX:** You must use the address of the VM hosting Docker in the URL (not localhost). This address is shown when starting Docker, or you can get the *docker-address* by running the command ````docker-machine ip default```` Then point your browser to *http://docker-address:9990* and follow along with the instructions in the IPython notebook.


### PR DESCRIPTION
I had trouble running Neural Networks are Weird on OSX. The installation was flawless (THANK YOU!) but I didn't realize that I had to use the docker-machine IP address to connect. I was quite stumped, but got good help from DEKHTIARJonathan who got me on the right path. Two thoughts:
1. The attached patch updates the README.md to tell how to proceed on OSX.
2. You might also update the startup instructions to say port 9990, not port 8888. (It currently says... 
   
   `[I 16:42:38.020 NotebookApp] The IPython Notebook is running at: http://0.0.0.0:8888/`
